### PR TITLE
fix memory leak

### DIFF
--- a/mpg.c
+++ b/mpg.c
@@ -103,5 +103,7 @@ int main(int argc, char **argv[]) {
 	int usleep(dsec);
 	printf("%s\n",pass);
 
+	free(pass);
+
 	return 0;
 }


### PR DESCRIPTION
Valgrind reports there is a memory leak (unfreed allocated memory). It reports that `malloc()` is always called one time more than `free()` is called.

This PR fixes the leak by free()ing `pass` after we're done using it.