### PR TITLE
Use secure method(s) of generating random numbers

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 default:
-	gcc mpg.c -o mpg
+	gcc mpg.c srandom.c -o mpg
 clean:
 	rm mpg
 install: 

--- a/mpg.c
+++ b/mpg.c
@@ -1,7 +1,12 @@
 #include <stdio.h>
+#include <strings.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
+#include <string.h>
+
+#include "srandom.h"
 
 char* gen(unsigned int len) {
 	unsigned int random;
@@ -9,50 +14,21 @@ char* gen(unsigned int len) {
 	unsigned int i;
 	char *pass;
 
-	char latin[] = {
+	char dict[] = {
 		'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q',
-		'r','s','t','u','v','w','x','y','z'
-	};
-
-	char ulatin[] = {
+		'r','s','t','u','v','w','x','y','z',
 		'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R',
-		'S','T','U','V','W','X','Y','Z'
-	};
-
-	char ansi[] = {
+		'S','T','U','V','W','X','Y','Z',
 		'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '!','@','#','$','%','^',
 		'&','*','(',')','-','=','+','.',',',':',';','"','?'
 	};
+	uint32_t dict_len = ((uint32_t)strlen(dict))-1;
 
-	pass = (char *) malloc (len * sizeof(char)); /*allocating pass on memory.*/
-
+	pass = (char *) malloc(len * sizeof(char)); /*allocating pass on memory.*/
 	/*generating random sequences.*/
-	ilatin = len - rand() % (len + 1);
-	iulatin = len - ilatin - rand() % (len - ilatin + 1);
-
-	if (iulatin > 0) {
-		iansi = len - ilatin - iulatin;
-	}
-	else {
-		iansi = len - ilatin;
-	}
-
 	for (i = 0; i < len; i++) {
-		random = rand() % 100;
-		if (random > 50) {
-			pass[i] = latin[rand() % sizeof(latin)];
-		}
-		else if (random > 20 && random <= 50) {
-			pass[i] = ulatin[rand() % sizeof(ulatin)];
-		}
-		else {
-			pass[i] = ansi[rand() % sizeof(ansi)];
-		}
+		pass[i] = dict[urand_int(dict_len)];
 	}
-
-	/*delay 1 second to generate password to avoid 
-	* people having the same password.*/
-	system("sleep 01");
 
 	return pass;
 }

--- a/mpg.c
+++ b/mpg.c
@@ -14,18 +14,16 @@ char* gen(unsigned int len) {
 	unsigned int i;
 	char *pass;
 
-	char dict[] = {
-		'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q',
-		'r','s','t','u','v','w','x','y','z',
-		'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R',
-		'S','T','U','V','W','X','Y','Z',
-		'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '!','@','#','$','%','^',
-		'&','*','(',')','-','=','+','.',',',':',';','"','?'
-	};
-	uint32_t dict_len = ((uint32_t)strlen(dict))-1;
+	char *dict = "abcdefghijklmnopqrstuvwxyz" \
+	             "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
+	             "0123456789!@#$%^&*()-=+.,:;\"?";
 
-	pass = (char *) malloc(len * sizeof(char)); /*allocating pass on memory.*/
-	/*generating random sequences.*/
+	uint32_t dict_len = ((uint32_t)strlen(dict));
+
+	/* allocating pass on memory. */
+	pass = (char *)malloc(len * sizeof(char));
+
+	/* generate random sequence. */
 	for (i = 0; i < len; i++) {
 		pass[i] = dict[urand_int(dict_len)];
 	}
@@ -50,7 +48,7 @@ int main(int argc, char **argv[]) {
 
 	int tty = isatty(fileno(stdout));
 
-	/*if there's no first argument, show help.*/
+	/* if there's no first argument, show help. */
 
 	if (!argv[1]) {
 		if(tty) {

--- a/mpg.c
+++ b/mpg.c
@@ -103,5 +103,7 @@ int main(int argc, char **argv[]) {
 	int usleep(dsec);
 	printf("%s\n",pass);
 
+	free(pass);
+
 	return 0;
 }

--- a/mpg.c
+++ b/mpg.c
@@ -40,12 +40,10 @@ void printLogo() {
 }
 
 int main(int argc, char **argv[]) {
-	srand(time(0));
 	unsigned int len;
 	char *pass;
 
 	/* determine if stdout is connected to a terminal */
-
 	int tty = isatty(fileno(stdout));
 
 	/* if there's no first argument, show help. */
@@ -74,9 +72,7 @@ int main(int argc, char **argv[]) {
 	}
 
 	pass = gen(len);
-	int usleep(dsec);
-	printf("%s\n",pass);
-
+	printf("%s\n", pass);
 	free(pass);
 
 	return 0;

--- a/srandom.c
+++ b/srandom.c
@@ -1,0 +1,60 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "srandom.h"
+
+/**
+ * Get a random uint32_t from /dev/urandom.
+ * This is very roughly based on how OpenBSD's arc4random() uses its
+ * keystream to generate a random uint32, but instead of a ChaCha20-based
+ * keystream we just use raw data from /dev/urandom.
+ */
+void get_urandom(uint32_t *val) {
+	int urand = open("/dev/urandom", O_RDONLY);
+	if (urand == -1) {
+		printf("panic: could not open /dev/urandom.\n");
+		exit(1);
+	}
+
+	unsigned char *ks = malloc(sizeof(*val));
+	memset(ks, 0, sizeof(*val));
+
+	// fill keystream with sizeof(*val) random data from /dev/urandom
+	size_t result = read(urand, ks, sizeof(*val));
+ 	if (result != sizeof(*val)) {
+		printf("panic: read incorrect amount of data.\n");
+		exit(1);
+	}
+	close(urand);
+
+	// copy random data into val
+	memcpy(val, ks, sizeof(*val));
+
+	// zero out the keystream and free it since we don't need it anymore
+	memset(ks, 0, sizeof(*val));
+	free(ks);
+}
+
+uint32_t urand_int(uint32_t limit) {
+#if defined(__OpenBSD__) || defined(__APPLE__)
+	/**
+	 * On apple and openbsd, arc4random(), a cryptographically secure random
+	 * number generation function can be used.
+	 */
+	return arc4random() % limit;
+#else 
+	/**
+	 * On linux and everything else we need to use /dev/urandom to generate
+	 * cryptographically secure pseudorandom numbers. This is a little more
+	 * involved than macos/openbsd (see: get_urandom() above).
+	 */
+	uint32_t val;
+	get_urandom(&val);
+	return val % limit;
+#endif /* __OpenBSD__ || __APPLE__ */
+}
+

--- a/srandom.h
+++ b/srandom.h
@@ -1,0 +1,7 @@
+#ifndef __SRAND_H__
+#define __SRAND_H__
+#include <stdint.h>
+
+uint32_t urand_int(uint32_t limit);
+
+#endif /*__SRAND_H__*/


### PR DESCRIPTION
Generating cryptographically-secure random passwords requires a sufficiently pseudorandom sequence of numbers. `random()` is not sufficiently random.

So I've written some functions that make use of either `arc4random()` (on platforms that support it), or `/dev/urandom` to generate a random integer (see `srandom.c`).

In doing so I've also simplified the inner workings of the `gen()` function to make it a bit cleaner.

(Merge #4 before this one).